### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/specs.cpp
+++ b/src/specs.cpp
@@ -40,7 +40,7 @@ arma::vec ridge (const arma::vec y,const arma::mat x,arma::mat XX) {
     arma::mat x_train = x.rows(0,tau-1); arma::mat x_test = x.rows(tau,t-1);
     arma::mat xx = x_train.t() * x_train; arma::vec xy = x_train.t() * y_train;
     arma::vec s = svd(xx); //singular values of x'x
-    arma::vec a; a << 0.0 << arma::endr << (max(s)*tol - min(s))/(1-tol) << arma::endr; //vector with (0,LB)
+    arma::vec a({ 0.0, (max(s)*tol - min(s))/(1-tol) });  //vector with (0,LB)
     double lambda_min = max(a); //minimum penalty to ensure good conditioning
     arma::vec lambdas = arma::zeros(6); //initial lambdas
     arma::vec CVs = arma::zeros(6); //store cross-validation results


### PR DESCRIPTION
This one-line change updates RcppArmadillo from the now deprecated `<<` initialization to brace initialization allowed since C++11 and long been the minimal standard with R too.  It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391